### PR TITLE
Support to build and install with meson

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,29 @@
 # List-library
 List library in C
 
+## Build
+
+To build and install:
+
+```
+mkdir build
+cd build
+meson ..
+meson install
+```
+
+To test:
+
+```
+mkdir build
+cd build
+meson -Dtests=true ..
+meson test
+
+```
+
+Or, you may just use `Makefile` to do it all by hand.
+
 ## Method Summary
 
 ### List :

--- a/include/meson.build
+++ b/include/meson.build
@@ -1,0 +1,1 @@
+install_headers('list.h', subdir: 'liblist')

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,5 @@
 project('liblist', 'c', default_options: ['default_library=both', 'warning_level=2'] )
 
-add_global_arguments('-fdiagnostics-color=always', language: 'c')
-
 include = include_directories('include', 'include/private', 'subprojects')
 
 subdir('include')

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,17 @@
+project('liblist', 'c', default_options: ['default_library=both', 'warning_level=2'] )
+
+add_global_arguments('-fdiagnostics-color=always', language: 'c')
+
+include = include_directories('include', 'include/private', 'subprojects')
+
+subdir('include')
+subdir('src')
+
+if get_option('tests')
+    subdir('tests')
+endif
+
+liblist_dep = declare_dependency(include_directories : include, link_with : liblist)
+
+pkg_mod = import('pkgconfig')
+pkg_mod.generate(libraries : liblist, version: '1.0', name: 'liblist', filebase : 'liblist', description : 'List library in C')

--- a/meson.build
+++ b/meson.build
@@ -9,7 +9,7 @@ if get_option('tests')
     subdir('tests')
 endif
 
-liblist_dep = declare_dependency(include_directories : include, link_with : liblist)
+liblist_dep = declare_dependency(include_directories: include, link_with: liblist)
 
 pkg_mod = import('pkgconfig')
-pkg_mod.generate(libraries : liblist, version: '1.0', name: 'liblist', filebase : 'liblist', description : 'List library in C')
+pkg_mod.generate(liblist, version: '1.0', name: 'liblist', filebase: 'liblist', subdirs: 'liblist', description: 'List library in C')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('tests', type : 'boolean', value : false)

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,0 +1,19 @@
+src = [
+    'list_remove.c',
+    'list_clone.c',
+    'list_get.c',
+    'list_contain.c',
+    'list_index_of.c',
+    'list_set.c',
+    'list_count.c',
+    'list_sub_list.c',
+    'list_add.c',
+    'list_remove_range.c',
+    'list.c',
+    'list_stat.c',
+    'list_destructor.c',
+    'list_reverse.c',
+    'list_to_array.c'
+]
+
+liblist = library('list', src, include_directories : include, install : true)

--- a/subprojects/boxfort.wrap
+++ b/subprojects/boxfort.wrap
@@ -1,0 +1,4 @@
+[wrap-git]
+directory = boxfort
+url = https://github.com/Snaipe/BoxFort.git
+revision = 1f0c6e94a8e5279389b209477faa333752ff5298

--- a/subprojects/criterion.wrap
+++ b/subprojects/criterion.wrap
@@ -1,0 +1,4 @@
+[wrap-git]
+url = https://github.com/Snaipe/Criterion
+revision = head
+clone-recursive = true

--- a/subprojects/libffi.wrap
+++ b/subprojects/libffi.wrap
@@ -1,0 +1,4 @@
+[wrap-git]
+directory=libffi
+url=https://gitlab.freedesktop.org/gstreamer/meson-ports/libffi.git
+revision=meson

--- a/subprojects/libgit2.wrap
+++ b/subprojects/libgit2.wrap
@@ -1,0 +1,4 @@
+[wrap-git]
+directory=libgit2
+url=https://github.com/libgit2/libgit2
+revision=v0.25.1

--- a/subprojects/nanomsg.wrap
+++ b/subprojects/nanomsg.wrap
@@ -1,0 +1,5 @@
+[wrap-git]
+directory = nanomsg
+url = https://github.com/nanomsg/nanomsg
+revision = master
+depth = 1

--- a/subprojects/nanopb.wrap
+++ b/subprojects/nanopb.wrap
@@ -1,0 +1,4 @@
+[wrap-git]
+directory = nanopb
+url = https://github.com/nanopb/nanopb
+revision = nanopb-0.4.0

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,0 +1,22 @@
+src_test = [
+    'tests_list_set.c',
+    'tests_list_contain.c',
+    'tests_list_sub_list.c',
+    'tests_list_to_array.c',
+    'tests_list_remove.c',
+    'tests_list_stat.c',
+    'tests_list_clone.c',
+    'tests_list_remove_data.c',
+    'tests_list_index_of.c',
+    'tests_list_add.c',
+    'tests_list_reverse.c',
+    'tests_list_remove_range.c',
+    'tests_list_count.c',
+    'tests_list_get.c',
+    'tests_list.c',
+    'tests_list_destructor.c'
+]
+
+criterion = dependency('criterion', fallback: ['criterion', 'criterion'])
+test_exe = executable('unit_tests', src_test, include_directories: include, link_with: liblist, dependencies: criterion)
+test('liblist test', test_exe)


### PR DESCRIPTION
I'm about to use some lightweight list C library in my project, and found this one.

Still I can't use it as is, because it is to be used as meson subproject, so it has to be able to be built with meson (e.g. include `meson.build` file, etc.)

So I decided to implement support for it (in addition, now it can be automatically installed if needed, and includes a `pkg-config` file to be recognized as some project's dependency).